### PR TITLE
초기 렌더링 시 다크 모드 깜빡임 에러 (dark mode flash error) 해결

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com//fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome againist localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}/src",
+            "skipFiles": [
+                "${workspaceFolder}/<node_internals>/**", "${workspaceFolder}/node_modules/**"
+            ]
+        }
+    ]
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,12 +1,29 @@
-/**
- * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
- *
- * See: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/
- */
+import React from "react";
 
-/**
- * @type {import('gatsby').GatsbySSR['onRenderBody']}
- */
-exports.onRenderBody = ({ setHtmlAttributes }) => {
-  setHtmlAttributes({ lang: `ko` })
+const functionToScript = callbackFn => String(callbackFn)
+
+const setInitThemeMode = () => {
+  if (typeof window !== 'undefined') {
+    const $body = document.querySelector('body')
+    // prefers-color-scheme 값을 확인 해 시스템의 컬러모드 초기값으로 사용
+    const prefersColorScheme = window.matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light'
+    // 이젠에 방문했다면 local storage 에 theme 값이 저장되어 있을 예정
+    const localTheme = localStorage.getItem('theme')
+    /**
+     * local storage에 저장된 값이 없으면 os에 지정된 prefers-color-scheme에 따라 테마를 선택하기
+     */
+    const initialTheme = localTheme || prefersColorScheme
+    $body?.classList.add(initialTheme)
+  }
+}
+
+const setInitThemeModeScript = functionToScript(setInitThemeMode)
+const codeRunOnClient = `(${setInitThemeModeScript})()`
+
+const MagicScriptTag = () => {
+  return <script dangerouslySetInnerHTML={{__html: codeRunOnClient}}/>
+}
+
+export const onRenderBody = ({setPreBodyComponents}) => {
+  setPreBodyComponents(<MagicScriptTag key="setInitThemeMode-script"/>)
 }

--- a/src/GlobalNavigation/GlobalNavigation.style.ts
+++ b/src/GlobalNavigation/GlobalNavigation.style.ts
@@ -3,6 +3,7 @@ import { Link } from 'gatsby'
 
 export const Container = styled.header<{ isHidden: boolean }>`
   width: 100%;
+  height: var(--gnb-height);
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/Layout/Layout.style.ts
+++ b/src/Layout/Layout.style.ts
@@ -4,7 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding-top: var(--padding-xl);
+  padding-top: var(--gnb-height);
   color: var(--color-text);
   background-color: var(--color-background);
 `

--- a/src/components/CategoryHeader/CategoryHeader.style.tsx
+++ b/src/components/CategoryHeader/CategoryHeader.style.tsx
@@ -11,6 +11,7 @@ export const Container = styled.div`
   box-shadow: rgba(0, 0, 0, 0.08) 0px 0px 15px;
   border: 2px solid var(--color-table-border);
   border-radius: 12px;
+  margin-top: var(--padding-s);
 `
 
 // category list

--- a/src/components/Common/Image/index.tsx
+++ b/src/components/Common/Image/index.tsx
@@ -59,7 +59,7 @@ const Image = ({ src, size = 'm', isCircle = false, ...rest }: ImageProps) => {
   return <SImage size={size} isCircle={isCircle} image={childImageSharp.gatsbyImageData} alt={publicURL} {...rest} />
 }
 
-const SImage = styled((props: GatsbyImgProps) => <GatsbyImage {...props} />)`
+const SImage = styled(({ isCircle, ...rest }: GatsbyImgProps) => <GatsbyImage {...rest} />)`
   width: ${({ size }) => size && ImageSizeMap[size]};
   height: ${({ size }) => size && ImageSizeMap[size]};
   border-radius: ${({ isCircle }) => isCircle && '50%'};

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled'
 
+import useBlogConfig from '@/hooks/useBlogConfig'
+
 const Footer = () => {
-  return <Container>@ 2025 Developer Hoeun, Powered By Gatsby</Container>
+  const { author } = useBlogConfig()
+  return <Container>@ 2025 Developer {author}, Powered By Gatsby.</Container>
 }
 
 export default Footer

--- a/src/styles/Globalstyles.tsx
+++ b/src/styles/Globalstyles.tsx
@@ -22,7 +22,7 @@ const styles = css`
     --padding-xl: 100px;
     --padding-l: 60px;
     --padding-m: 50px;
-    --padding-s: 40px;
+    --padding-s: 30px;
     --main-content-width: 760px;
     --space-l: 16px;
     --space-m: 12px;
@@ -32,6 +32,7 @@ const styles = css`
     --icon-large: 36px;
     --icon-xLarge: 64px;
     /* etc */
+    --gnb-height: 64px;
 
     @media ${media.medium} {
       --padding-xl: 90px;


### PR DESCRIPTION
#  About
1. 초기 렌더링 시 다크 모드 깜빡임 에러 (dark mode flash error)해결

## Description
***현재 적용 과정***
- local storage 에 저장된 값이 없으면 os에 지정된 prefers-color-scheme 에 따라 테마를 선택하기
- 초기 테마를 정하면 body 태그에 class를 추가 해서 css-variable 적용
***문제***
- body 태그에 theme 관련 태그(.dark)를 추가하기전 html 이 렌더링되어 light 모드로 렌더링됨
- html 이 렌더링 된 후 js로직이 동작해 dark모드로 바꿈
### 해결방법
***이론***
- 컴파일 시 HTML 을 생성할 때 모든 콘텐츠(페이지 자체) 앞에 <script> 태그를 삽입(blocking HTML)
- 해당 스크립트 태그에서 사용자의 색상 기본 설정이 무엇인지 알아보기
- JavaScript 를 사용하여 CSS 변수 업데이트
***실제 적용 ***
- gatsby-srr.js 에서 `onRenderBody`와 `setPreBodyComponents`를 활용해서 body 태그전에 테마를 설정하는 script 로직 삽입
- [codesandbox 예제](https://codesandbox.io/p/sandbox/zg3rx8)

```
// gatsby-srr.js

const setInitThemeMode = () => {
  // 초기 테마 설정 로직 : src/utils/themeMode.ts와 같은 로직
}

const setInitThemeModeScript = functionToScript(setInitThemeMode)
const codeRunOnClient = `(${setInitThemeModeScript})()`

const MagicScriptTag = () => {
  return <script dangerouslySetInnerHTML={{ __html: codeRunOnClient }} />
}

export const onRenderBody = ({ setPreBodyComponents }) => {
  setPreBodyComponents(<MagicScriptTag key="setInitThemeMode-script" />)
}
```

## Ref
- https://www.joshwcomeau.com/react/dark-mode/#updating-html-in-gatsby-8
- https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/
- https://victorzhou.com/blog/dark-mode-gatsby/