### PR TITLE
SEO 컴포넌트 리팩토링 및 og:image 에러 수정

### DIFF
--- a/blog-config.js
+++ b/blog-config.js
@@ -3,11 +3,13 @@ require('dotenv').config({
 })
 
 module.exports = {
+  lang: 'ko',
   siteName: `Hoeun.blog`,
   author: 'Hoeun(WangHoeun)',
   description: `안녕하세요. 프론트엔드 개발자 왕호은입니다. 꾸준한 성장을 좋아합니다.`,
   siteUrl: 'https://hoeun0723.github.io',
-  image: `./static/profile-image.png`,
+  profileImage: `static/profile-image.png`,
+  mainOgImage: `static/main-og-image.png`,
   keywords: ['개발블로그', '포트폴리오', 'gatsby'],
   favicon: './static/pencil.png',
   social: {

--- a/blog-config.js
+++ b/blog-config.js
@@ -8,8 +8,8 @@ module.exports = {
   author: 'Hoeun(WangHoeun)',
   description: `안녕하세요. 프론트엔드 개발자 왕호은입니다. 꾸준한 성장을 좋아합니다.`,
   siteUrl: 'https://hoeun0723.github.io',
-  profileImage: `static/profile-image.png`,
-  mainOgImage: `static/main-og-image.png`,
+  profileImage: `profile-image.png`,
+  mainOgImage: `main-og-image.png`,
   keywords: ['개발블로그', '포트폴리오', 'gatsby'],
   favicon: './static/pencil.png',
   social: {

--- a/src/components/Common/Image/index.tsx
+++ b/src/components/Common/Image/index.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled'
-import { graphql, useStaticQuery } from 'gatsby'
 import { GatsbyImage, IGatsbyImageData } from 'gatsby-plugin-image'
-import { useMemo } from 'react'
 
-import { GatsbyImageDataType } from '@/types/gatsby.type'
+import useStaticImage from '@/hooks/useStaticImage'
 
 const ImageSizeMap = {
   s: 'var(--icon-medium)',
@@ -19,37 +17,14 @@ interface ImageProps {
   isCircle?: boolean
 }
 
-interface ImageNode {
-  node: {
-    relativePath: string
-    extension: string
-    publicURL: string
-    childImageSharp: {
-      gatsbyImageData: IGatsbyImageData
-    }
-  }
-}
-
-interface AssetsImageType {
-  images: {
-    edges: ImageNode[]
-  }
-}
-
 interface GatsbyImgProps extends Omit<ImageProps, 'src'> {
-  image: GatsbyImageDataType
+  image: IGatsbyImageData
   alt: string
   className?: string
 }
 
 const Image = ({ src, size = 'm', isCircle = false, ...rest }: ImageProps) => {
-  const assetImages = useStaticQuery<AssetsImageType>(imageQuery)
-
-  const target = useMemo(
-    () => assetImages.images.edges.find(({ node }) => src === node.relativePath),
-    [assetImages, src],
-  )
-
+  const target = useStaticImage({ src })
   if (!target) return null
 
   const {
@@ -70,20 +45,3 @@ const SImage = styled(({ isCircle, ...rest }: GatsbyImgProps) => <GatsbyImage {.
 `
 
 export default Image
-
-const imageQuery = graphql`
-  query {
-    images: allFile(filter: { sourceInstanceName: { eq: "static" } }) {
-      edges {
-        node {
-          relativePath
-          extension
-          publicURL
-          childImageSharp {
-            gatsbyImageData(layout: CONSTRAINED)
-          }
-        }
-      }
-    }
-  }
-`

--- a/src/components/PostDetail/PostDetail.style.tsx
+++ b/src/components/PostDetail/PostDetail.style.tsx
@@ -1,11 +1,9 @@
 import styled from '@emotion/styled'
-import { GatsbyImage } from 'gatsby-plugin-image'
-
-import { GatsbyImageDataType } from '@/types/gatsby.type'
+import { GatsbyImage, IGatsbyImageData } from 'gatsby-plugin-image'
 
 //Header
 interface GatsbyImgProps {
-  image: GatsbyImageDataType
+  image: IGatsbyImageData
   alt: string
   className?: string
 }

--- a/src/components/PostDetail/PostHeader/index.tsx
+++ b/src/components/PostDetail/PostHeader/index.tsx
@@ -1,10 +1,10 @@
-import { GatsbyImageDataType } from '@/types/gatsby.type'
+import { IGatsbyImageData } from 'gatsby-plugin-image'
 
 import * as S from '../PostDetail.style'
 import PostHeaderInfo, { PostHeadInfoProps } from './PostHeader.info'
 
 interface PostHeaderProps extends PostHeadInfoProps {
-  thumbnail: GatsbyImageDataType
+  thumbnail: IGatsbyImageData
 }
 
 const PostHeader = ({ title, date, categories, thumbnail, readingTime }: PostHeaderProps) => {

--- a/src/components/PostDetail/index.tsx
+++ b/src/components/PostDetail/index.tsx
@@ -1,5 +1,4 @@
 import PostFooter from '@/components/PostDetail/PostFooter'
-import useBlogConfig from '@/hooks/useBlogConfig'
 import Layout from '@/Layout'
 import { PostPageItemType } from '@/types/PostItem.types'
 
@@ -9,11 +8,10 @@ import SEO from '../SEO'
 
 interface PostPageInfoProps {
   postPageInfo: PostPageItemType
-  href: string
+  pathname: string
 }
 
-const PostDetail = ({ postPageInfo, href }: PostPageInfoProps) => {
-  const { author, favicon, seo, siteName } = useBlogConfig()
+const PostDetail = ({ postPageInfo, pathname }: PostPageInfoProps) => {
   const {
     node: {
       tableOfContents,
@@ -35,15 +33,11 @@ const PostDetail = ({ postPageInfo, href }: PostPageInfoProps) => {
   return (
     <Layout>
       <SEO
-        author={author}
-        siteUrl={href}
-        siteName={siteName}
         title={title}
+        pathname={pathname}
         description={summary}
         image={publicURL}
         keywords={categories}
-        favicon={favicon}
-        seo={seo}
         readingTime={readingTime.text}
       />
       <PostHeader

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -1,20 +1,34 @@
 import { Helmet } from 'react-helmet'
 
+import useBlogConfig from '@/hooks/useBlogConfig'
 import { SEOConfigType } from '@/types/gatsby.type'
 
 const SEO = ({
-  lang = 'ko',
-  author,
-  siteName,
-  siteUrl,
-  title = siteName,
+  //변동
+  title,
+  pathname,
   description,
   image,
   keywords,
-  favicon,
-  seo,
   readingTime,
 }: SEOConfigType) => {
+  const {
+    lang,
+    author,
+    siteName,
+    favicon,
+    seo,
+    siteUrl,
+    mainOgImage,
+    description: mainDesc,
+    keywords: mainKeywords,
+  } = useBlogConfig()
+  // params가 없으면 기본 config type을 사용하기
+  const pageUrl = `${siteUrl}${pathname || ``}`
+  keywords = keywords || mainKeywords
+  description = description || mainDesc
+  image = image ? `${siteUrl}${image}` : `${siteUrl}/${mainOgImage}`
+  title = title || siteName
   return (
     <Helmet htmlAttributes={{ lang }}>
       <title>{title}</title>
@@ -30,16 +44,16 @@ const SEO = ({
       <meta property="og:site_name" content={siteName} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      <meta property="og:image" content={`${siteUrl}${image}`} />
-      <meta property="og:url" content={siteUrl} />
+      <meta property="og:image" content={image} />
+      <meta property="og:url" content={pageUrl} />
       <meta property="og:locale" content="ko_KR" />
       <meta property="og:locale:alternate" content="es_ES" />
       {/* twitter cards tags additive with th og: tags  */}
       <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:domain" content={siteUrl} />
+      <meta name="twitter:domain" content={pageUrl} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      <meta name="twitter:image" content={`${siteUrl}${image}`} />
+      <meta name="twitter:image" content={image} />
       <meta name="twitter:image:alt" content={description} />
       <meta name="twitter:label1" content="Time to read" />
       <meta name="twitter:data1" content={readingTime} />

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -1,6 +1,7 @@
 import { Helmet } from 'react-helmet'
 
 import useBlogConfig from '@/hooks/useBlogConfig'
+import useStaticImage from '@/hooks/useStaticImage'
 import { SEOConfigType } from '@/types/gatsby.type'
 
 const SEO = ({
@@ -23,11 +24,13 @@ const SEO = ({
     description: mainDesc,
     keywords: mainKeywords,
   } = useBlogConfig()
+  const target = useStaticImage({ src: mainOgImage })
+  const mainOgImagePath = target?.node.publicURL || ''
   // params가 없으면 기본 config type을 사용하기
   const pageUrl = `${siteUrl}${pathname || ``}`
   keywords = keywords || mainKeywords
   description = description || mainDesc
-  image = image ? `${siteUrl}${image}` : `${siteUrl}/${mainOgImage}`
+  image = image ? `${siteUrl}${image}` : `${siteUrl}/${mainOgImagePath}`
   title = title || siteName
   return (
     <Helmet htmlAttributes={{ lang }}>

--- a/src/hooks/useBlogConfig.ts
+++ b/src/hooks/useBlogConfig.ts
@@ -18,7 +18,8 @@ const useBlogConfig = () => {
             siteName
             description
             siteUrl
-            image
+            profileImage
+            mainOgImage
             keywords
             favicon
             social {

--- a/src/hooks/useStaticImage.ts
+++ b/src/hooks/useStaticImage.ts
@@ -1,0 +1,54 @@
+import { graphql, useStaticQuery } from 'gatsby'
+import { IGatsbyImageData } from 'gatsby-plugin-image'
+import { useMemo } from 'react'
+
+interface ImageNode {
+  node: {
+    relativePath: string
+    extension: string
+    publicURL: string
+    childImageSharp: {
+      gatsbyImageData: IGatsbyImageData
+    }
+  }
+}
+
+interface AssetsImageType {
+  images: {
+    edges: ImageNode[]
+  }
+}
+
+export interface useStaticImageProps {
+  src: string
+}
+
+const useStaticImage = ({ src }: useStaticImageProps) => {
+  const assetImages = useStaticQuery<AssetsImageType>(imageQuery)
+
+  const target = useMemo(
+    () => assetImages.images.edges.find(({ node }) => src === node.relativePath),
+    [assetImages, src],
+  )
+
+  return target
+}
+
+export default useStaticImage
+
+const imageQuery = graphql`
+  query {
+    images: allFile(filter: { sourceInstanceName: { eq: "static" } }) {
+      edges {
+        node {
+          relativePath
+          extension
+          publicURL
+          childImageSharp {
+            gatsbyImageData(layout: CONSTRAINED)
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,6 @@ import CategoryHeader from '@/components/CategoryHeader'
 import { CategoryListProps } from '@/components/CategoryHeader/CategoryList'
 import PostList from '@/components/PostList'
 import SEO from '@/components/SEO'
-import useBlogConfig from '@/hooks/useBlogConfig'
 import Layout from '@/Layout'
 import { PostListItemType, PostType } from '@/types/PostItem.types'
 
@@ -28,7 +27,6 @@ const IndexPage = ({
     allMarkdownRemark: { edges },
   },
 }: IndexPageProps) => {
-  const { author, siteName, siteUrl, description, image, keywords, favicon, seo } = useBlogConfig()
   const parsed: ParsedQuery<string> = queryString.parse(hash)
   const selectedCategory = typeof parsed.category !== 'string' || !parsed.category ? 'All' : parsed.category
   // category 프로퍼티 값이 문자열 형태가 아니거나 존재하지 않는 경우에는 기본적으로 카테고리 값을 All로 지정하고, 그러지 않은 경우에는 파싱한 값을 지정
@@ -58,16 +56,7 @@ const IndexPage = ({
   )
   return (
     <Layout>
-      <SEO
-        author={author}
-        siteUrl={siteUrl}
-        siteName={siteName}
-        description={description}
-        image={image}
-        keywords={keywords}
-        favicon={favicon}
-        seo={seo}
-      />
+      <SEO />
       <CategoryHeader selectedCategory={selectedCategory} categoryList={categoryList} />
       <PostList selectedCategory={selectedCategory} posts={edges} />
     </Layout>

--- a/src/templates/post.template.tsx
+++ b/src/templates/post.template.tsx
@@ -11,7 +11,7 @@ interface PostTemplateProps {
     }
   }
   location: {
-    href: string
+    pathname: string
   }
 }
 
@@ -19,9 +19,9 @@ const PostTemplate = ({
   data: {
     allMarkdownRemark: { edges },
   },
-  location: { href },
+  location: { pathname },
 }: PostTemplateProps) => {
-  return <PostDetail postPageInfo={edges[0]} href={href} />
+  return <PostDetail postPageInfo={edges[0]} pathname={pathname} />
 }
 
 export default PostTemplate

--- a/src/types/PostItem.types.ts
+++ b/src/types/PostItem.types.ts
@@ -1,4 +1,4 @@
-import { GatsbyImageDataType } from './gatsby.type'
+import { IGatsbyImageData } from 'gatsby-plugin-image'
 
 export type PostFrontmatterType = {
   title: string
@@ -7,7 +7,7 @@ export type PostFrontmatterType = {
   summary: string
   thumbnail: {
     childImageSharp: {
-      gatsbyImageData: GatsbyImageDataType
+      gatsbyImageData: IGatsbyImageData
     }
     publicURL: string
   }

--- a/src/types/gatsby.type.ts
+++ b/src/types/gatsby.type.ts
@@ -9,27 +9,35 @@ export interface GatsbyImgProps {
 }
 
 export interface SEOConfigType {
-  lang?: string
-  author: string
-  siteName: string
-  siteUrl: string
   title?: string
-  description: string
-  image: string
-  keywords: string[]
-  favicon: string
-  seo: {
-    google: string
-    naver: string
-  }
+  pathname?: string
+  description?: string
+  image?: string
+  keywords?: string[]
   readingTime?: string
 }
 
-export interface ConfigType extends SEOConfigType {
+/**
+ * blog-config.js의 정보 타입
+ */
+export interface ConfigType {
+  lang: 'ko' | 'en'
+  author: string
+  siteName: string
+  description: string
+  siteUrl: string
+  profileImage: string
+  mainOgImage: string
+  keywords: string[]
+  favicon: string
   social: {
     email: string
     github: string
     til: string
+  }
+  seo: {
+    google: string
+    naver: string
   }
   utterances: {
     src: string

--- a/src/types/gatsby.type.ts
+++ b/src/types/gatsby.type.ts
@@ -1,9 +1,7 @@
 import { IGatsbyImageData } from 'gatsby-plugin-image'
 
-export type GatsbyImageDataType = IGatsbyImageData
-
 export interface GatsbyImgProps {
-  image: GatsbyImageDataType
+  image: IGatsbyImageData
   alt: string
   className?: string
 }


### PR DESCRIPTION
# About
1. og:image 태그 경로 설정
2. useStaticImage hooks
3. blog-config 이미지 경로 수정
4. main-og-image 추가

## Description
### 1. og:image 태그 경로 설정

> The pathname prop will be the relative path of the page so you need to construct an absolute URL with siteUrl.
> 출처: https://www.gatsbyjs.com/docs/how-to/adding-common-features/adding-seo-component/#seo-component



검색 결과 [stackoverflow - Open graph can resolve relative url?](https://stackoverflow.com/questions/9858577/open-graph-can-resolve-relative-url)에서도 og:image의 경로는 상대경로가 아닌 절대경로로 해줘야한다고 한다.

blog-config.js에서 설정한 mainOgImage를 seo컴포넌트에 적용하기 위해 2,3번을 진행했다.

### useStaticImage hooks
`src/common/image`컴포넌트 내부에 있는` static` 폴더 내부에 원하는 이미지를 가져오는 query를 useStaticImage hooks로 분리했다.

```

export interface useStaticImageProps {
   src: string
 }

 const useStaticImage = ({ src }: useStaticImageProps) => {
   const assetImages = useStaticQuery<AssetsImageType>(imageQuery)

   const target = useMemo(
     () => assetImages.images.edges.find(({ node }) => src === node.relativePath),
     [assetImages, src],
   )

   return target
 }

 export default useStaticImage

 const imageQuery = graphql`
   query {
     images: allFile(filter: { sourceInstanceName: { eq: "static" } }) {
       edges {
         node {
           relativePath
           extension
           publicURL
           childImageSharp {
             gatsbyImageData(layout: CONSTRAINED)
           }
         }
       }
     }
   }
 `
```

사용 예시


```
// SEO
const target = useStaticImage({ src: mainOgImage })
const mainOgImagePath = target?.node.publicURL || ''

// Image
const Image = ({ src, size = 'm', isCircle = false, ...rest }: ImageProps) => {
  const target = useStaticImage({ src })

  if (!target) return null

  const {
    node: { childImageSharp, publicURL },
  } = target

  return <SImage size={size} isCircle={isCircle} image={childImageSharp.gatsbyImageData} alt={publicURL} {...rest} />
}
```

### 3. blog-config 이미지 경로 수정
2번에서 image 를 static 폴더에서 가져오기 위해 blog-config 에서 이미지 경로를 다음과 같이 수정

```

- profileImage: `static/profile-image.png`,
- mainOgImage: 'static/main-og-image.png',
+ profileImage: `profile-image.png`,
+ mainOgImage: 'main-og-image.png',
```

cf> favicon
`favicon: 'static/pencil.png'`의 경우 `gatsby-plugin-manifest `플러그인으로 렌더링해서 경로까지 적어줘야 한다.


## Result
### 메인 페이지